### PR TITLE
Add mysql role

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -18,3 +18,4 @@ group_packages:
   - htop
   - rsync
   - cmake
+  - ant

--- a/roles/mysql/handlers/main.yml
+++ b/roles/mysql/handlers/main.yml
@@ -1,0 +1,3 @@
+---
+- name: Restart MySQL
+  service: name=mysql state=restarted

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+
+- name: Install the MySQL packages
+  apt:
+    name: "{{ item }}"
+    state: installed
+    update_cache: yes
+  with_items:
+    - mysql-server-5.7
+    - mysql-client-5.7
+    - python-mysqldb
+    - libmysqlclient-dev
+
+- name: Update MySQL root password for all root accounts
+  mysql_user:
+    name: root
+    host: "{{ item }}"
+    password: "{{ mysql_root_pass }}"
+    state: present
+  with_items:
+    - "{{ ansible_hostname }}"
+    - 127.0.0.1
+    - ::1
+    - localhost
+
+- name: Copy the root credentials as .my.cnf file
+  template:
+    src: root.cnf.j2
+    dest: ~/.my.cnf
+    mode: 0600
+
+- name: Ensure Anonymous user(s) are not in the database
+  mysql_user:
+    name: ''
+    host: "{{ item }}"
+    state: absent
+  with_items:
+    - localhost
+    - "{{ ansible_hostname }}"
+
+- name: Remove the test database
+  mysql_db:
+    name: test
+    state: absent
+  notify:
+    - Restart MySQL

--- a/roles/mysql/templates/root.cnf.j2
+++ b/roles/mysql/templates/root.cnf.j2
@@ -1,0 +1,3 @@
+[client]
+user=root
+password={{ mysql_root_pass }}

--- a/roles/mysql/vars/main.yml
+++ b/roles/mysql/vars/main.yml
@@ -1,0 +1,1 @@
+mysql_root_pass: allyourbasesarebelongtous

--- a/site.yml
+++ b/site.yml
@@ -9,3 +9,4 @@
   remote_user: root
   roles:
     - scala
+    - mysql


### PR DESCRIPTION
Mysql is required for using the dejavu artifact. I made it a role, modifying [this configuration](https://stackoverflow.com/questions/26597926/install-mysql-with-ansible-on-ubuntu)