### PR TITLE
Add libcurl and ant

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -18,3 +18,5 @@ group_packages:
   - htop
   - rsync
   - cmake
+  - ant
+  - libcurl4-openssl-dev


### PR DESCRIPTION
Since I'm using MySQL through Docker, I can cancel #2 

However, I still need:

- `ant`, to build something of SourcererCC
- `libcurl4-openssl-dev`, as a dependency for the R `RCurl` package.